### PR TITLE
gnuradio: use fails_with to control compilers

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -6,7 +6,6 @@ class Gnuradio < Formula
   sha1 '8d3846dc1d00c60b74f06c0bb8f40d57ee257b5a'
   head 'http://gnuradio.org/git/gnuradio.git'
 
-  depends_on 'apple-gcc42' => :build
   depends_on 'cmake' => :build
   depends_on 'Cheetah' => :python
   depends_on 'lxml' => :python
@@ -32,6 +31,8 @@ class Gnuradio < Formula
     cause "Fails to compile .S files."
   end
 
+  fails_with :llvm
+
   def options
     [
       ['--with-qt', 'Build gr-qtgui.'],
@@ -44,12 +45,6 @@ class Gnuradio < Formula
   end
 
   def install
-
-	  # Force compilation with gcc-4.2
-	  ENV['CC'] = '/usr/local/bin/gcc-4.2'
-	  ENV['LD'] = '/usr/local/bin/gcc-4.2'
-	  ENV['CXX'] = '/usr/local/bin/g++-4.2'
-
     mkdir 'build' do
       args = ["-DCMAKE_PREFIX_PATH=#{prefix}", "-DQWT_INCLUDE_DIRS=#{HOMEBREW_PREFIX}/lib/qwt.framework/Headers"] + std_cmake_args
       args << '-DENABLE_GR_QTGUI=OFF' unless ARGV.include?('--with-qt')


### PR DESCRIPTION
It's much cleaner to select compilers using the `fails_with` than by specifying a dependency and hardcoding the compiler. If the user doesn't have any compatible compilers, the build will error out and they'll be given a helpful error message telling them how to get gcc-4.2.

A few reasons why this approach works better:
- Users on Xcode 4.1 and earlier already have gcc-4.2 and don't need the one from homebrew/dupes.
- Some users on Xcode 4.2 and later still have gcc-4.2 leftover if they'd had 4.1 or earlier installed in the past.
- The gcc-4.2 from homebrew/dupes is only compatible with Lion or later.
- Hardcoding `/usr/local/bin/gcc-4.2` doesn't work for users on 4.1 or earlier (they have it at a different location), or users with Homebrew installed to an alternate prefix.
