### PR TITLE
hacks to work on osx with clang

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -148,5 +148,161 @@ index 049d4ff..43e6857 100644
    <customwidget>
     <class>QwtWheel</class>
 
+diff --git a/gnuradio-core/src/lib/io/ppio_ppdev.h b/gnuradio-core/src/lib/io/ppio_ppdev.h
+index 1f86d7e..9b2c4f1 100644
+--- a/gnuradio-core/src/lib/io/ppio_ppdev.h
++++ b/gnuradio-core/src/lib/io/ppio_ppdev.h
+@@ -35,7 +35,7 @@ typedef boost::shared_ptr<ppio_ppdev> ppio_ppdev_sptr;
+  */
+ 
+ class GR_CORE_API ppio_ppdev : public ppio {
+-  friend GR_CORE_API ppio_ppdev_sptr make_ppio_ppdev (int which = 0);
++  friend GR_CORE_API ppio_ppdev_sptr make_ppio_ppdev (int which);
+   ppio_ppdev (int which = 0);
+ 
+  public:
+diff --git a/gr-qtgui/include/qtgui_util.h b/gr-qtgui/include/qtgui_util.h
+index 2deaddb..7ba9b64 100644
+--- a/gr-qtgui/include/qtgui_util.h
++++ b/gr-qtgui/include/qtgui_util.h
+@@ -27,6 +27,7 @@
+ #include <gr_qtgui_api.h>
+ #include <qwt_plot_picker.h>
+ #include <qwt_picker_machine.h>
++#include <qwt_plot_canvas.h>
+ 
+ 
+ class GR_QTGUI_API QwtDblClickPlotPicker: public QwtPlotPicker
+diff --git a/gr-qtgui/lib/ConstellationDisplayPlot.cc b/gr-qtgui/lib/ConstellationDisplayPlot.cc
+index 7a595fe..89eb6d1 100644
+--- a/gr-qtgui/lib/ConstellationDisplayPlot.cc
++++ b/gr-qtgui/lib/ConstellationDisplayPlot.cc
+@@ -107,7 +107,7 @@ ConstellationDisplayPlot::ConstellationDisplayPlot(QWidget* parent)
+   memset(_realDataPoints, 0x0, _numPoints*sizeof(double));
+   memset(_imagDataPoints, 0x0, _numPoints*sizeof(double));
+ 
+-  _zoomer = new ConstellationDisplayZoomer(canvas());
++  _zoomer = new ConstellationDisplayZoomer(dynamic_cast<QwtPlotCanvas *>(canvas()));
+ 
+ #if QWT_VERSION < 0x060000
+   _zoomer->setSelectionFlags(QwtPicker::RectSelection | QwtPicker::DragSelection);
+@@ -134,7 +134,7 @@ ConstellationDisplayPlot::ConstellationDisplayPlot(QWidget* parent)
+   _zoomer->setTrackerPen(c);
+ 
+   // emit the position of clicks on widget
+-  _picker = new QwtDblClickPlotPicker(canvas());
++  _picker = new QwtDblClickPlotPicker(dynamic_cast<QwtPlotCanvas *>(canvas()));
+ 
+ #if QWT_VERSION < 0x060000
+   connect(_picker, SIGNAL(selected(const QwtDoublePoint &)),
+diff --git a/gr-qtgui/lib/FrequencyDisplayPlot.cc b/gr-qtgui/lib/FrequencyDisplayPlot.cc
+index b74d460..d84fcdb 100644
+--- a/gr-qtgui/lib/FrequencyDisplayPlot.cc
++++ b/gr-qtgui/lib/FrequencyDisplayPlot.cc
+@@ -249,7 +249,7 @@ FrequencyDisplayPlot::FrequencyDisplayPlot(QWidget* parent)
+   replot();
+ 
+   // emit the position of clicks on widget
+-  _picker = new QwtDblClickPlotPicker(canvas());
++  _picker = new QwtDblClickPlotPicker(dynamic_cast<QwtPlotCanvas*>(canvas()));
+ 
+ #if QWT_VERSION < 0x060000
+   connect(_picker, SIGNAL(selected(const QwtDoublePoint &)),
+@@ -263,7 +263,7 @@ FrequencyDisplayPlot::FrequencyDisplayPlot(QWidget* parent)
+   _magnifier = new QwtPlotMagnifier(canvas());
+   _magnifier->setAxisEnabled(QwtPlot::xBottom, false);
+ 
+-  _zoomer = new FreqDisplayZoomer(canvas(), 0);
++  _zoomer = new FreqDisplayZoomer(dynamic_cast<QwtPlotCanvas*>(canvas()), 0);
+ 
+ #if QWT_VERSION < 0x060000
+   _zoomer->setSelectionFlags(QwtPicker::RectSelection | QwtPicker::DragSelection);
+diff --git a/gr-qtgui/lib/TimeDomainDisplayPlot.cc b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+index 84b09af..31073de 100644
+--- a/gr-qtgui/lib/TimeDomainDisplayPlot.cc
++++ b/gr-qtgui/lib/TimeDomainDisplayPlot.cc
+@@ -102,7 +102,7 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
+   _xAxisPoints = new double[_numPoints];
+   memset(_xAxisPoints, 0x0, _numPoints*sizeof(double));
+ 
+-  _zoomer = new TimeDomainDisplayZoomer(canvas(), 0);
++  _zoomer = new TimeDomainDisplayZoomer(dynamic_cast<QwtPlotCanvas*>(canvas()), 0);
+ 
+ #if QWT_VERSION < 0x060000
+   _zoomer->setSelectionFlags(QwtPicker::RectSelection | QwtPicker::DragSelection);
+@@ -169,7 +169,7 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
+   _panner->setMouseButton(Qt::MidButton);
+ 
+   // emit the position of clicks on widget
+-  _picker = new QwtDblClickPlotPicker(canvas());
++  _picker = new QwtDblClickPlotPicker(dynamic_cast<QwtPlotCanvas*>(canvas()));
+ 
+ #if QWT_VERSION < 0x060000
+   connect(_picker, SIGNAL(selected(const QwtDoublePoint &)),
+@@ -195,7 +195,7 @@ TimeDomainDisplayPlot::TimeDomainDisplayPlot(int nplots, QWidget* parent)
+   _zoomer->setTrackerPen(c);
+ 
+   QwtLegend* legendDisplay = new QwtLegend(this);
+-  legendDisplay->setItemMode(QwtLegend::CheckableItem);
++  legendDisplay->setDefaultItemMode(QwtLegendData::Checkable);
+   insertLegend(legendDisplay);
+ 
+   connect(this, SIGNAL( legendChecked(QwtPlotItem *, bool ) ),
+diff --git a/gr-qtgui/lib/WaterfallDisplayPlot.cc b/gr-qtgui/lib/WaterfallDisplayPlot.cc
+index 63eb57f..e34b6fa 100644
+--- a/gr-qtgui/lib/WaterfallDisplayPlot.cc
++++ b/gr-qtgui/lib/WaterfallDisplayPlot.cc
+@@ -329,7 +329,7 @@ WaterfallDisplayPlot::WaterfallDisplayPlot(QWidget* parent)
+   // MidButton for the panning
+   // RightButton: zoom out by 1
+   // Ctrl+RighButton: zoom out to full size
+-  _zoomer = new WaterfallZoomer(canvas(), 0);
++  _zoomer = new WaterfallZoomer(dynamic_cast<QwtPlotCanvas *>(canvas()), 0);
+ #if QWT_VERSION < 0x060000
+   _zoomer->setSelectionFlags(QwtPicker::RectSelection | QwtPicker::DragSelection);
+ #endif
+@@ -343,7 +343,7 @@ WaterfallDisplayPlot::WaterfallDisplayPlot(QWidget* parent)
+   _panner->setMouseButton(Qt::MidButton);
+ 
+   // emit the position of clicks on widget
+-  _picker = new QwtDblClickPlotPicker(canvas());
++  _picker = new QwtDblClickPlotPicker(dynamic_cast<QwtPlotCanvas *>(canvas()));
+ #if QWT_VERSION < 0x060000
+   connect(_picker, SIGNAL(selected(const QwtDoublePoint &)),
+    this, SLOT(OnPickerPointSelected(const QwtDoublePoint &)));
+diff --git a/gr-qtgui/lib/spectrumdisplayform.cc b/gr-qtgui/lib/spectrumdisplayform.cc
+index dd9011d..0da804b 100644
+--- a/gr-qtgui/lib/spectrumdisplayform.cc
++++ b/gr-qtgui/lib/spectrumdisplayform.cc
+@@ -50,9 +50,9 @@ SpectrumDisplayForm::SpectrumDisplayForm(QWidget* parent)
+   MaxHoldCheckBox_toggled( false );
+ 
+   WaterfallMaximumIntensityWheel->setRange(-200, 0);
+-  WaterfallMaximumIntensityWheel->setTickCnt(50);
++  WaterfallMaximumIntensityWheel->setTickCount(50);
+   WaterfallMinimumIntensityWheel->setRange(-200, 0);
+-  WaterfallMinimumIntensityWheel->setTickCnt(50);
++  WaterfallMinimumIntensityWheel->setTickCount(50);
+   WaterfallMinimumIntensityWheel->setValue(-200);
+ 
+   _peakFrequency = 0;
+@@ -597,13 +597,13 @@ void
+ SpectrumDisplayForm::WaterfallAutoScaleBtnCB()
+ {
+   double minimumIntensity = _noiseFloorAmplitude - 5;
+-  if(minimumIntensity < WaterfallMinimumIntensityWheel->minValue()){
+-    minimumIntensity = WaterfallMinimumIntensityWheel->minValue();
++  if(minimumIntensity < WaterfallMinimumIntensityWheel->minimum()){
++    minimumIntensity = WaterfallMinimumIntensityWheel->minimum();
+   }
+   WaterfallMinimumIntensityWheel->setValue(minimumIntensity);
+   double maximumIntensity = _peakAmplitude + 10;
+-  if(maximumIntensity > WaterfallMaximumIntensityWheel->maxValue()){
+-    maximumIntensity = WaterfallMaximumIntensityWheel->maxValue();
++  if(maximumIntensity > WaterfallMaximumIntensityWheel->maximum()){
++    maximumIntensity = WaterfallMaximumIntensityWheel->maximum();
+   }
+   WaterfallMaximumIntensityWheel->setValue(maximumIntensity);
+   waterfallMaximumIntensityChangedCB(maximumIntensity);
 
 


### PR DESCRIPTION
Not sure if this is useful to others, but here's what I had to change in order to get gnuradio to build on osx. It wouldn't build with gcc42 or gcc44.

Summary of issues:
- Some member names in QT libs were referenced incorrectly (it seems QT may have renamed them at some point).
- Friend declaration can't provide default args (clang enforces this).
- `canvas()` returns parent class, need to upcast via `dynamic_cast` to correct qt type (I'm hardly a C++ expert so this could be completely the wrong thing to do)
