### PR TITLE
Add depends_on 'pkg-config' to hackrf.rb

### DIFF
--- a/hackrf.rb
+++ b/hackrf.rb
@@ -8,6 +8,7 @@ class Hackrf < Formula
   head 'https://github.com/mossmann/hackrf.git'
 
   depends_on 'cmake' => :build
+  depends_on 'pkg-config' => :build
   depends_on 'libusb'
 
   def install


### PR DESCRIPTION
Tried to install hackrf without having pkg-config installed:

```
andres@andress-mbp ~ $ brew install hackrf
Error: hackrf is a head-only formula
Install with `brew install --HEAD hackrf`
andres@andress-mbp ~ $ brew install --HEAD hackrf
....
==> Installing hackrf
==> Cloning https://github.com/mossmann/hackrf.git
Updating /Library/Caches/Homebrew/hackrf--git
==> cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/hackrf/HEAD -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev
used as include directory in directory /tmp/hackrf-9M77No/host/libhackrf/src
-- Configuring incomplete, errors occurred!
See also "/tmp/hackrf-9M77No/host/CMakeFiles/CMakeOutput.log".
See also "/tmp/hackrf-9M77No/host/CMakeFiles/CMakeError.log".
READ THIS: https://github.com/Homebrew/homebrew/blob/master/share/doc/homebrew/Troubleshooting.md#troubleshooting
If reporting this issue please do so at (not Homebrew/homebrew):
https://github.com/robotastic/homebrew-hackrf/issues
```

Installed pkg-config manually:

```
andres@andress-mbp ~ $ brew install pkg-config
==> Downloading https://downloads.sf.net/project/machomebrew/Bottles/pkg-config-0.28.mavericks.bottle.2.tar.gz
Already downloaded: /Library/Caches/Homebrew/pkg-config-0.28.mavericks.bottle.2.tar.gz
==> Pouring pkg-config-0.28.mavericks.bottle.2.tar.gz
🍺  /usr/local/Cellar/pkg-config/0.28: 10 files, 604K
```

After that hacrf builds:

```
andres@andress-mbp ~ $ brew install --HEAD hackrf
==> Installing hackrf from robotastic/homebrew-hackrf
==> Cloning https://github.com/mossmann/hackrf.git
Updating /Library/Caches/Homebrew/hackrf--git
==> cmake . -DCMAKE_INSTALL_PREFIX=/usr/local/Cellar/hackrf/HEAD -DCMAKE_BUILD_TYPE=None -DCMAKE_FIND_FRAMEWORK=LAST -DCMAKE_VERBOSE_MAKEFILE=ON -Wno-dev
==> make install
🍺  /usr/local/Cellar/hackrf/HEAD: 14 files, 216K, built in 8 seconds
```
