### PR TITLE
Resolves issue with Qt + boost

### DIFF
--- a/gnuradio.rb
+++ b/gnuradio.rb
@@ -305,4 +305,356 @@ index dd9011d..0da804b 100644
    WaterfallMaximumIntensityWheel->setValue(maximumIntensity);
    waterfallMaximumIntensityChangedCB(maximumIntensity);
 
-
+diff --git a/gnuradio-core/src/lib/general/gr_random_pdu.h b/gnuradio-core/src/lib/general/gr_random_pdu.h
+index 8b8beb6..6323fc8 100644
+--- a/gnuradio-core/src/lib/general/gr_random_pdu.h
++++ b/gnuradio-core/src/lib/general/gr_random_pdu.h
+@@ -28,8 +28,10 @@
+ #include <gr_message.h>
+ #include <gr_msg_queue.h>
+ 
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/random.hpp>
+ #include <boost/generator_iterator.hpp>
++#endif
+ 
+ class gr_random_pdu;
+ typedef boost::shared_ptr<gr_random_pdu> gr_random_pdu_sptr;
+diff --git a/gnuradio-core/src/lib/general/gri_fft.h b/gnuradio-core/src/lib/general/gri_fft.h
+index 65e9d04..9fd6801 100644
+--- a/gnuradio-core/src/lib/general/gri_fft.h
++++ b/gnuradio-core/src/lib/general/gri_fft.h
+@@ -28,7 +28,9 @@
+ 
+ #include <gr_core_api.h>
+ #include <gr_complex.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread.hpp>
++#endif
+ 
+ /*! \brief Helper function for allocating complex fft buffers
+  */
+diff --git a/gnuradio-core/src/lib/io/gr_file_sink_base.h b/gnuradio-core/src/lib/io/gr_file_sink_base.h
+index 8a70cee..e9332ae 100644
+--- a/gnuradio-core/src/lib/io/gr_file_sink_base.h
++++ b/gnuradio-core/src/lib/io/gr_file_sink_base.h
+@@ -24,7 +24,9 @@
+ #define INCLUDED_GR_FILE_SINK_BASE_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread.hpp>
++#endif
+ #include <cstdio>
+ 
+ /*!
+diff --git a/gnuradio-core/src/lib/io/gr_file_source.h b/gnuradio-core/src/lib/io/gr_file_source.h
+index 0478fba..59662fd 100644
+--- a/gnuradio-core/src/lib/io/gr_file_source.h
++++ b/gnuradio-core/src/lib/io/gr_file_source.h
+@@ -25,7 +25,9 @@
+ 
+ #include <gr_core_api.h>
+ #include <gr_sync_block.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread/mutex.hpp>
++#endif
+ 
+ class gr_file_source;
+ typedef boost::shared_ptr<gr_file_source> gr_file_source_sptr;
+diff --git a/gnuradio-core/src/lib/io/gr_socket_pdu.h b/gnuradio-core/src/lib/io/gr_socket_pdu.h
+index 2fedb31..87fbb1c 100644
+--- a/gnuradio-core/src/lib/io/gr_socket_pdu.h
++++ b/gnuradio-core/src/lib/io/gr_socket_pdu.h
+@@ -28,8 +28,10 @@
+ #include <gr_message.h>
+ #include <gr_msg_queue.h>
+ #include <gr_stream_pdu_base.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/array.hpp>
+ #include <boost/asio.hpp>
++#endif
+ #include <iostream>
+ 
+ class gr_socket_pdu;
+diff --git a/gnuradio-core/src/lib/io/gr_wavfile_sink.h b/gnuradio-core/src/lib/io/gr_wavfile_sink.h
+index 162151b..b377557 100644
+--- a/gnuradio-core/src/lib/io/gr_wavfile_sink.h
++++ b/gnuradio-core/src/lib/io/gr_wavfile_sink.h
+@@ -26,7 +26,9 @@
+ #include <gr_core_api.h>
+ #include <gr_sync_block.h>
+ #include <gr_file_sink_base.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread.hpp>
++#endif
+ 
+ class gr_wavfile_sink;
+ typedef boost::shared_ptr<gr_wavfile_sink> gr_wavfile_sink_sptr;
+diff --git a/gnuradio-core/src/lib/io/i2c.h b/gnuradio-core/src/lib/io/i2c.h
+index 6b7f25a..89729b0 100644
+--- a/gnuradio-core/src/lib/io/i2c.h
++++ b/gnuradio-core/src/lib/io/i2c.h
+@@ -24,7 +24,9 @@
+ #define INCLUDED_I2C_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
+ 
+ class i2c;
+ typedef boost::shared_ptr<i2c> i2c_sptr;
+diff --git a/gnuradio-core/src/lib/io/i2c_bbio.h b/gnuradio-core/src/lib/io/i2c_bbio.h
+index 6bf47b9..ff79f22 100644
+--- a/gnuradio-core/src/lib/io/i2c_bbio.h
++++ b/gnuradio-core/src/lib/io/i2c_bbio.h
+@@ -24,7 +24,10 @@
+ #define INCLUDED_I2C_BBIO_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
++
+ 
+ class i2c_bbio;
+ typedef boost::shared_ptr<i2c_bbio>  i2c_bbio_sptr;
+diff --git a/gnuradio-core/src/lib/io/microtune_xxxx.h b/gnuradio-core/src/lib/io/microtune_xxxx.h
+index b2646d3..b76f5a1 100644
+--- a/gnuradio-core/src/lib/io/microtune_xxxx.h
++++ b/gnuradio-core/src/lib/io/microtune_xxxx.h
+@@ -24,7 +24,10 @@
+ #define INCLUDED_MICROTUNE_XXXX_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
++
+ 
+ class i2c;
+ typedef boost::shared_ptr<i2c> i2c_sptr;
+diff --git a/gnuradio-core/src/lib/io/microtune_xxxx_eval_board.h b/gnuradio-core/src/lib/io/microtune_xxxx_eval_board.h
+index 7fd784a..7a1e3fb 100644
+--- a/gnuradio-core/src/lib/io/microtune_xxxx_eval_board.h
++++ b/gnuradio-core/src/lib/io/microtune_xxxx_eval_board.h
+@@ -24,7 +24,9 @@
+ #define INCLUDED_MICROTUNE_XXXX_EVAL_BOARD_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
+ 
+ class microtune_xxxx;
+ 
+diff --git a/gnuradio-core/src/lib/io/ppio.h b/gnuradio-core/src/lib/io/ppio.h
+index d99f7bf..b2b3003 100644
+--- a/gnuradio-core/src/lib/io/ppio.h
++++ b/gnuradio-core/src/lib/io/ppio.h
+@@ -24,7 +24,9 @@
+ #define INCLUDED_PPIO_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
+ 
+ class ppio;
+ typedef boost::shared_ptr<ppio> ppio_sptr;
+diff --git a/gnuradio-core/src/lib/io/sdr_1000.h b/gnuradio-core/src/lib/io/sdr_1000.h
+index c00608a..8af008c 100644
+--- a/gnuradio-core/src/lib/io/sdr_1000.h
++++ b/gnuradio-core/src/lib/io/sdr_1000.h
+@@ -24,7 +24,10 @@
+ #define INCLUDED_SDR_1000_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
++
+ 
+ class ppio;
+ typedef boost::shared_ptr<ppio> ppio_sptr;
+diff --git a/gnuradio-core/src/lib/runtime/gr_basic_block.h b/gnuradio-core/src/lib/runtime/gr_basic_block.h
+index 024159c..81f873c 100644
+--- a/gnuradio-core/src/lib/runtime/gr_basic_block.h
++++ b/gnuradio-core/src/lib/runtime/gr_basic_block.h
+@@ -26,16 +26,20 @@
+ #include <gr_core_api.h>
+ #include <gr_runtime_types.h>
+ #include <gr_sptr_magic.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/enable_shared_from_this.hpp>
+ #include <boost/function.hpp>
++#endif
+ #include <gr_msg_accepter.h>
+ #include <string>
+ #include <deque>
+ #include <map>
+ #include <gr_io_signature.h>
+ #include <gruel/thread.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/foreach.hpp>
+ #include <boost/thread/condition_variable.hpp>
++#endif
+ #include <iostream>
+ 
+ /*!
+diff --git a/gnuradio-core/src/lib/runtime/gr_buffer.h b/gnuradio-core/src/lib/runtime/gr_buffer.h
+index 631ee30..b012b49 100644
+--- a/gnuradio-core/src/lib/runtime/gr_buffer.h
++++ b/gnuradio-core/src/lib/runtime/gr_buffer.h
+@@ -25,7 +25,9 @@
+ 
+ #include <gr_core_api.h>
+ #include <gr_runtime_types.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/weak_ptr.hpp>
++#endif
+ #include <gruel/thread.h>
+ #include <gr_tags.h>
+ #include <deque>
+diff --git a/gnuradio-core/src/lib/runtime/gr_hier_block2_detail.h b/gnuradio-core/src/lib/runtime/gr_hier_block2_detail.h
+index b38dae3..54097c7 100644
+--- a/gnuradio-core/src/lib/runtime/gr_hier_block2_detail.h
++++ b/gnuradio-core/src/lib/runtime/gr_hier_block2_detail.h
+@@ -25,7 +25,9 @@
+ #include <gr_core_api.h>
+ #include <gr_hier_block2.h>
+ #include <gr_flat_flowgraph.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/utility.hpp>
++#endif
+ 
+ /*!
+  * \ingroup internal
+diff --git a/gnuradio-core/src/lib/runtime/gr_scheduler.h b/gnuradio-core/src/lib/runtime/gr_scheduler.h
+index 6d13032..b4e2e49 100644
+--- a/gnuradio-core/src/lib/runtime/gr_scheduler.h
++++ b/gnuradio-core/src/lib/runtime/gr_scheduler.h
+@@ -23,7 +23,9 @@
+ #define INCLUDED_GR_SCHEDULER_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/utility.hpp>
++#endif
+ #include <gr_block.h>
+ #include <gr_flat_flowgraph.h>
+ 
+diff --git a/gnuradio-core/src/lib/runtime/gr_select_handler.h b/gnuradio-core/src/lib/runtime/gr_select_handler.h
+index c4c3592..4b1dd15 100644
+--- a/gnuradio-core/src/lib/runtime/gr_select_handler.h
++++ b/gnuradio-core/src/lib/runtime/gr_select_handler.h
+@@ -24,7 +24,9 @@
+ #define INCLUDED_GR_SELECT_HANDLER_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
+ 
+ class gr_select_handler;
+ typedef boost::shared_ptr<gr_select_handler> gr_select_handler_sptr;
+diff --git a/gnuradio-core/src/lib/runtime/gr_types.h b/gnuradio-core/src/lib/runtime/gr_types.h
+index db13e45..4329210 100644
+--- a/gnuradio-core/src/lib/runtime/gr_types.h
++++ b/gnuradio-core/src/lib/runtime/gr_types.h
+@@ -24,7 +24,9 @@
+ #define INCLUDED_GR_TYPES_H
+ 
+ #include <gr_core_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
+ #include <vector>
+ #include <stddef.h>        // size_t
+ 
+diff --git a/gnuradio-core/src/lib/runtime/gr_unittests.h b/gnuradio-core/src/lib/runtime/gr_unittests.h
+index 9fbf228..98a5eca 100644
+--- a/gnuradio-core/src/lib/runtime/gr_unittests.h
++++ b/gnuradio-core/src/lib/runtime/gr_unittests.h
+@@ -33,8 +33,10 @@
+ #include <unistd.h>
+ #include <string>
+ 
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/filesystem/operations.hpp>
+ #include <boost/filesystem/path.hpp>
++#endif
+ 
+ static std::string get_unittest_path(const std::string &filename){
+     boost::filesystem::path path = boost::filesystem::current_path() / ".unittests";
+diff --git a/gr-blocks/include/blocks/file_sink_base.h b/gr-blocks/include/blocks/file_sink_base.h
+index 3eeb0e6..209e777 100644
+--- a/gr-blocks/include/blocks/file_sink_base.h
++++ b/gr-blocks/include/blocks/file_sink_base.h
+@@ -24,7 +24,9 @@
+ #define INCLUDED_GR_FILE_SINK_BASE_H
+ 
+ #include <blocks/api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread.hpp>
++#endif
+ #include <cstdio>
+ 
+ namespace gr {
+diff --git a/gr-digital/include/digital/packet_header_default.h b/gr-digital/include/digital/packet_header_default.h
+index e4c9945..8ce5680 100644
+--- a/gr-digital/include/digital/packet_header_default.h
++++ b/gr-digital/include/digital/packet_header_default.h
+@@ -24,7 +24,9 @@
+ 
+ #include <gr_tags.h>
+ #include <digital/api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/enable_shared_from_this.hpp>
++#endif
+ 
+ namespace gr {
+   namespace digital {
+diff --git a/gr-digital/include/digital_constellation.h b/gr-digital/include/digital_constellation.h
+index 5503fb4..6788149 100644
+--- a/gr-digital/include/digital_constellation.h
++++ b/gr-digital/include/digital_constellation.h
+@@ -27,7 +27,9 @@
+ #include <vector>
+ #include <math.h>
+ #include <gr_complex.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/enable_shared_from_this.hpp>
++#endif
+ #include <digital_metric_type.h>
+ 
+ /************************************************************/
+diff --git a/gr-digital/include/digital_ofdm_equalizer_base.h b/gr-digital/include/digital_ofdm_equalizer_base.h
+index 2fc5cf5..a7a05a3 100644
+--- a/gr-digital/include/digital_ofdm_equalizer_base.h
++++ b/gr-digital/include/digital_ofdm_equalizer_base.h
+@@ -25,7 +25,9 @@
+ #include <digital_api.h>
+ #include <gr_tags.h>
+ #include <gr_complex.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/enable_shared_from_this.hpp>
++#endif
+ 
+ class digital_ofdm_equalizer_base;
+ typedef boost::shared_ptr<digital_ofdm_equalizer_base> digital_ofdm_equalizer_base_sptr;
+diff --git a/gr-pager/lib/pager_flex_frame.h b/gr-pager/lib/pager_flex_frame.h
+index a2e8f23..da31ee3 100644
+--- a/gr-pager/lib/pager_flex_frame.h
++++ b/gr-pager/lib/pager_flex_frame.h
+@@ -22,7 +22,9 @@
+ #define INCLUDED_PAGER_FLEX_FRAME_H
+ 
+ #include <pager_api.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/shared_ptr.hpp>
++#endif
+ 
+ class pager_flex_frame;
+ typedef boost::shared_ptr<pager_flex_frame> pager_flex_frame_sptr;

--- a/gqrx.rb
+++ b/gqrx.rb
@@ -118,6 +118,8 @@ index f52ffa3..cbdc9c6 100644
      }
  
      if (d_nb1_on)
+
+
 diff --git a/applications/gqrx/receiver.cpp b/applications/gqrx/receiver.cpp
 index c856fb7..1d7700b 100644
 --- a/applications/gqrx/receiver.cpp
@@ -131,3 +133,100 @@ index c856fb7..1d7700b 100644
      {
  #ifndef QT_NO_DEBUG_OUTPUT
          std::cout << "No change in output device:" << std::endl
+
+
+diff --git a/applications/gqrx/main.cpp b/applications/gqrx/main.cpp
+index 793f7a4..bf99a55 100644
+--- a/applications/gqrx/main.cpp
++++ b/applications/gqrx/main.cpp
+@@ -24,7 +24,10 @@
+ #include "gqrx.h"
+ 
+ #include <iostream>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/program_options.hpp>
++#endif
+ namespace po = boost::program_options;
+
+
+diff --git a/dsp/rx_agc_xx.h b/dsp/rx_agc_xx.h
+index 55dcb4d..81762ee 100644
+--- a/dsp/rx_agc_xx.h
++++ b/dsp/rx_agc_xx.h
+@@ -22,7 +22,10 @@
+ 
+ #include <gr_sync_block.h>
+ #include <gr_complex.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread/mutex.hpp>
++#endif
+ #include <dsp/agc_impl.h>
+ 
+ class rx_agc_cc;
+
+
+diff --git a/dsp/rx_fft.h b/dsp/rx_fft.h
+index bf332d2..3fdd22c 100644
+--- a/dsp/rx_fft.h
++++ b/dsp/rx_fft.h
+@@ -24,8 +24,11 @@
+ #include <gri_fft.h>
+ #include <gr_firdes.h>       /* contains enum win_type */
+ #include <gr_complex.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread/mutex.hpp>
+ #include <boost/circular_buffer.hpp>
++#endif
+ 
+ 
+ #define MAX_FFT_SIZE 32768
+
+
+diff --git a/dsp/rx_noise_blanker_cc.h b/dsp/rx_noise_blanker_cc.h
+index 11ca0d1..f5e9a50 100644
+--- a/dsp/rx_noise_blanker_cc.h
++++ b/dsp/rx_noise_blanker_cc.h
+@@ -22,7 +22,10 @@
+ 
+ #include <gr_sync_block.h>
+ #include <gr_complex.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread/mutex.hpp>
++#endif
+ 
+ class rx_nb_cc;
+
+
+diff --git a/dsp/sniffer_f.h b/dsp/sniffer_f.h
+index 1a3167e..6e583c2 100644
+--- a/dsp/sniffer_f.h
++++ b/dsp/sniffer_f.h
+@@ -21,8 +21,11 @@
+ #define SNIFFER_F_H
+ 
+ #include <gr_sync_block.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/thread/mutex.hpp>
+ #include <boost/circular_buffer.hpp>
++#endif
+ 
+ 
+ class sniffer_f;
+
+
+diff --git a/qtgui/ioconfig.cpp b/qtgui/ioconfig.cpp
+index f6e8bd5..5727ed9 100644
+--- a/qtgui/ioconfig.cpp
++++ b/qtgui/ioconfig.cpp
+@@ -29,7 +29,10 @@
+ #include <osmosdr/osmosdr_device.h>
+ #include <osmosdr/osmosdr_source_c.h>
+ #include <osmosdr/osmosdr_ranges.h>
++#ifndef Q_MOC_RUN  // See: https://bugreports.qt-project.org/browse/QTBUG-22829
+ #include <boost/foreach.hpp>
++#endif
+ 
+ #ifdef WITH_PULSEAUDIO
+ #include "pulseaudio/pa_device_list.h"
+
+


### PR DESCRIPTION
gqrx currently does not compile on Yosemite 10.10.2 and boost 1.57.0 via homebrew, due the issue mentioned below. This pull applies the workaround mentioned, and has allowed gqrx to be successfully compiled. Note that since gqrx has dependencies on gnuradio, some patches had to be made there as well.

https://bugreports.qt-project.org/browse/QTBUG-22829
