### PR TITLE
changed gr-baz branch from 3.6 to master

### DIFF
--- a/gr-baz.rb
+++ b/gr-baz.rb
@@ -2,7 +2,7 @@ require 'formula'
 
 class GrBaz < Formula
   homepage 'http://wiki.spench.net/wiki/Gr-baz'
-  head 'https://github.com/balint256/gr-baz.git', :branch => "3.6"
+  head 'https://github.com/balint256/gr-baz.git', :branch => "master"
 
   depends_on 'cmake' => :build
   depends_on 'gnuradio'


### PR DESCRIPTION
The 3.6 branch of gr-baz can't compile against GNU Radio 3.7.